### PR TITLE
Potential fix for code scanning alert no. 1: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -1,4 +1,6 @@
 name: Deploy to Github Page
+permissions:
+  contents: write
 on:
   push:
     branches: [ "main" ]


### PR DESCRIPTION
Potential fix for [https://github.com/aminsys/Expresence/security/code-scanning/1](https://github.com/aminsys/Expresence/security/code-scanning/1)

To fix the problem, add a `permissions` block to the workflow (either at the root level, or to the specific job if different jobs require different permissions). Since this workflow deploys to GitHub Pages—pushing via GITHUB_TOKEN—it minimally needs `contents: write` so it can push the built files to the repository, but no more. To reduce permissions to the least required, add the following to your workflow:

- Insert a `permissions` block under the root (above `jobs:`) specifying only `contents: write`.
- If you want to restrict the permissions for only the deploy job, you can instead add the block under that job.

In this case, since there appears to be only one job and it is responsible for deployment, adding to the root is simplest and least ambiguous.

No additional imports, definitions, or dependency changes are needed.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
